### PR TITLE
Fix broken libcluster link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ View the docs [here](https://hexdocs.pm/skycluster).
 
 # Deprecation warning
 
-This package is deprecated in favor of [bitwalker/libcluster](github.com/bitwalker/libcluster) implementation for service discovery and [phoenixframework/firenest](https://github.com/phoenixframework/firenest/) for messages broadcasting. 
+This package is deprecated in favor of [bitwalker/libcluster](https://github.com/bitwalker/libcluster) implementation for service discovery and [phoenixframework/firenest](https://github.com/phoenixframework/firenest/) for messages broadcasting. 
 
 We think that this approach will be more reusable for community, because separate tasks should be done with a separate building blocks of your application.
 


### PR DESCRIPTION
Libcluster link was being treated as a relative link.